### PR TITLE
fix(core): Initialize exercise state on page load

### DIFF
--- a/script.js
+++ b/script.js
@@ -90,6 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeTheme();
     initializeMuteState();
     initializeStats();
+    resetSession(); // Initialize the default exercise state
 
     updateFeedback("Welcome to FitTracker AI", "Choose an exercise and start your journey!", "fas fa-rocket");
     speak("Welcome to FitTracker AI! Your personal trainer is ready to help you achieve your fitness goals! Choose an exercise and let's get started!");


### PR DESCRIPTION
The application would crash with a TypeError if a workout was started for the default exercise without first clicking on an exercise card. This was because the 'exercisePhase' state variable was not initialized on load.

This fix addresses the issue by calling 'resetSession()' when the DOM is loaded, ensuring the application's state is properly initialized for the default exercise.